### PR TITLE
[TEST] Add api endpoints for microcephd

### DIFF
--- a/microceph/api/servers.go
+++ b/microceph/api/servers.go
@@ -19,6 +19,8 @@ var Servers = map[string]rest.Server{
 					resourcesCmd,
 					servicesCmd,
 					configsCmd,
+					stopServiceCmd,
+					startServiceCmd,
 					restartServiceCmd,
 					mdsServiceCmd,
 					mgrServiceCmd,

--- a/microceph/ceph/services.go
+++ b/microceph/ceph/services.go
@@ -257,3 +257,41 @@ func DeleteService(ctx context.Context, s interfaces.StateInterface, service str
 	return nil
 
 }
+
+// StopService stop a service in the node.
+func StopService(clusterServices types.Services, service string, hostname string) error {
+	if !isServicePlacementOnHost(clusterServices, service, hostname) {
+		logger.Info(
+			fmt.Sprintf("%s service is not on the current host", service),
+		)
+		return nil
+	}
+
+	err := snapStop(service, true)
+
+	if err != nil {
+		logger.Errorf("failed to stop daemon %q: %v", service, err)
+		return fmt.Errorf("failed to stop daemon %q: %w", service, err)
+	}
+
+	return nil
+}
+
+// StartService start a service in the node.
+func StartService(clusterServices types.Services, service string, hostname string) error {
+	if !isServicePlacementOnHost(clusterServices, service, hostname) {
+		logger.Info(
+			fmt.Sprintf("%s service is not on the current host", service),
+		)
+		return nil
+	}
+
+	err := snapStart(service, true)
+
+	if err != nil {
+		logger.Errorf("failed to start daemon %q: %v", service, err)
+		return fmt.Errorf("failed to start daemon %q: %w", service, err)
+	}
+
+	return nil
+}

--- a/microceph/client/services.go
+++ b/microceph/client/services.go
@@ -61,6 +61,36 @@ func SendServicePlacementReq(ctx context.Context, c *client.Client, data *types.
 	return nil
 }
 
+// StopService sends the request to stop the desired service on a target host
+func StopService(ctx context.Context, c *client.Client, target string, service string) error {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*120)
+	defer cancel()
+
+	c = c.UseTarget(target)
+	err := c.Query(queryCtx, "POST", types.ExtendedPathPrefix, api.NewURL().Path("services", "stop"), types.Service{Service: service}, nil)
+	if err != nil {
+		url := c.URL()
+		logger.Errorf("stop error: %v", err)
+		return fmt.Errorf("failed Forwarding To: %s: %w", url.String(), err)
+	}
+	return nil
+}
+
+// StartService sends the request to start the desired service on a target host
+func StartService(ctx context.Context, c *client.Client, target string, service string) error {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*120)
+	defer cancel()
+
+	c = c.UseTarget(target)
+	err := c.Query(queryCtx, "POST", types.ExtendedPathPrefix, api.NewURL().Path("services", "start"), types.Service{Service: service}, nil)
+	if err != nil {
+		url := c.URL()
+		logger.Errorf("stop error: %v", err)
+		return fmt.Errorf("failed Forwarding To: %s: %w", url.String(), err)
+	}
+	return nil
+}
+
 // Sends a request to the host to restart the provided service.
 func RestartService(ctx context.Context, c *client.Client, data *types.Services) error {
 	// 120 second timeout for waiting.

--- a/microceph/client/wrap.go
+++ b/microceph/client/wrap.go
@@ -14,6 +14,8 @@ type ClientInterface interface {
 	GetDisks(*microCli.Client) (types.Disks, error)
 	GetServices(*microCli.Client) (types.Services, error)
 	DeleteService(*microCli.Client, string, string) error
+	StopService(*microCli.Client, string, string) error
+	StartService(*microCli.Client, string, string) error
 	DeleteClusterMember(*microCli.Client, string, bool) error
 }
 
@@ -43,6 +45,16 @@ func (c ClientImpl) GetDisks(cli *microCli.Client) (types.Disks, error) {
 // GetServices wraps the GetServices function above
 func (c ClientImpl) GetServices(cli *microCli.Client) (types.Services, error) {
 	return GetServices(context.Background(), cli)
+}
+
+// StopService wraps the StopService function
+func (c ClientImpl) StopService(cli *microCli.Client, target string, service string) error {
+	return StopService(context.Background(), cli, target, service)
+}
+
+// StartService wraps the StartService function
+func (c ClientImpl) StartService(cli *microCli.Client, target string, service string) error {
+	return StartService(context.Background(), cli, target, service)
 }
 
 // DeleteService wraps the DeleteService function


### PR DESCRIPTION
Add two endpoints `services/stop` and `services/start` to enable stopping and starting snap service for cluster members. The endpoint only accept POST method.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

## Contributor's Checklist

Please check that you have:

- [ ] self-reviewed the code in this PR.
- [ ] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
